### PR TITLE
minor cleanup

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -409,12 +409,12 @@ class Analyzer(
 
         // Find aggregate expressions and evaluate them early, since they can't be evaluated in a
         // Sort.
-        val (aliasedAggregateList, withAggsRemoved) = resolvedOrdering.map {
+        val (withAggsRemoved, aliasedAggregateList) = resolvedOrdering.map {
           case aggOrdering if aggOrdering.collect { case a: AggregateExpression => a }.nonEmpty =>
             val aliased = Alias(aggOrdering.child, "_aggOrdering")()
-            (aliased :: Nil, aggOrdering.copy(child = aliased.toAttribute))
+            (aggOrdering.copy(child = aliased.toAttribute), aliased :: Nil)
 
-          case other => (Nil, other)
+          case other => (other, Nil)
         }.unzip
 
         val missing = unresolved ++ aliasedAggregateList.flatten


### PR DESCRIPTION
I think it might be a better idea to avoid using side effects of a `transform` to populate the `ArrayBuffer`.  Generally you should use `transform` for its result.  I also removed the addition of an index to the `Alias` (they will print out as `alias#GUID` already).  Finally, add a few comments to explain what we are doing.

Thoughts?
